### PR TITLE
arreglo validaciones en el form de solicitudes

### DIFF
--- a/src/Servicios/Licencias/Formulario/FormularioVisual.jsx
+++ b/src/Servicios/Licencias/Formulario/FormularioVisual.jsx
@@ -73,7 +73,8 @@ const FormularioVisual = ({
             <DatePicker
               label={'Desde'}
               disablePast
-              minDate={formData.fechaDesde !== '' ? dayjs(formData.fechaDesde, 'DD-MM-YYYY') : dayjs()}
+              // minDate={formData.fechaDesde !== '' ? dayjs(formData.fechaDesde, 'DD-MM-YYYY') : dayjs()}
+              minDate={dayjs()}
               defaultValue={formData.fechaDesde !== '' ? dayjs(formData.fechaDesde, 'DD-MM-YYYY') : dayjs()}
               value={formData.fechaDesde !== '' ? dayjs(formData.fechaDesde, 'DD-MM-YYYY') : null}
               onMonthChange={handleCambioAnio}

--- a/src/Servicios/Licencias/utils/validaciones.js
+++ b/src/Servicios/Licencias/utils/validaciones.js
@@ -18,8 +18,8 @@ function validarFechasLicencia(nuevaFechaDesde, nuevaFechaHasta, solicitudesPrev
 
   // Verificar si las fechas se superponen
   for (const solicitud of solicitudesFiltradas) {
-      const fechaDesde = convertirFecha(solicitud.fecha_desde);
-      const fechaHasta = convertirFecha(solicitud.fecha_hasta);
+      const fechaDesde = solicitud.fecha_desde ? convertirFecha(solicitud.fecha_desde) : null;
+      const fechaHasta = solicitud.fecha_hasta ? convertirFecha(solicitud.fecha_hasta) : null;
       const fechaPermiso = solicitud.fecha_permiso ? convertirFecha(solicitud.fecha_permiso) : null;
       const fechaCompensatoria = solicitud.dia_compensatorio ? convertirFecha(solicitud.dia_compensatorio) : null;
 
@@ -43,6 +43,7 @@ function validarFechasLicencia(nuevaFechaDesde, nuevaFechaHasta, solicitudesPrev
  */
 function convertirFecha(fecha) {
   // Reemplazar "/" por "-" para manejar ambos formatos
+  console.log(fecha);
   const fechaNormalizada = fecha.replace(/\//g, '-');
   const [dia, mes, año] = fechaNormalizada.split('-');
   return new Date(`${año}-${mes}-${dia}`);


### PR DESCRIPTION
1. Arreglo un error en el datapicker para fecha desde que no me dejaba poner una fecha anterior cada vez que seleccionaba.
2. Agrego un if ternario en la validación de fechas que verifica que no hayan solicitudes superpuestas ya que me tiraba error cuando no encontraba fecha desde si solicitaba un permiso y se debe a que puede no existir una solicitud con fecha desde.